### PR TITLE
Fixed this dependency as no es5 folder present

### DIFF
--- a/lib/PdfDocument.ts
+++ b/lib/PdfDocument.ts
@@ -1,7 +1,7 @@
 import { PDFDocumentProxy, PDFPageProxy, TextContent, TextContentItem } from 'pdfjs-dist';
 import { PdfTable } from './PdfTable';
 import { Options, PdfPage } from './types';
-const pdflib = require('pdfjs-dist/es5/build/pdf');
+const pdflib = require('pdfjs-dist/build/pdf');
 
 interface _PdfString {
     x: number; y: number; x2: number; y2: number; //w: number; h: number;


### PR DESCRIPTION
Only after making this requirement change can I import tables from the PDF. The es5 folder has been removed by the pdfjs devs.